### PR TITLE
fix(ios): inject Referer header in plugin WKWebView for YouTube embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,24 @@ await YoutubePlayer.initialize({
 - `YSC`: YouTube session cookie
 - `PREF`: User preferences cookie
 
+## Fix YouTube Error 152/153 in the Plugin WKWebView (iOS)
+
+The native fullscreen player uses its own `WKWebView`. On recent iOS versions, that WebView must send a valid HTTP `Referer` header when loading YouTube embed resources.
+
+The plugin now proxies YouTube requests from its internal player WebView and injects a valid `Referer` automatically. Configure the header with:
+
+```json
+{
+  "plugins": {
+    "YoutubePlayer": {
+      "refererHeader": "https://www.youtube.com"
+    }
+  }
+}
+```
+
+`refererHeader` defaults to `https://www.youtube.com` when omitted. This is separate from `patchRefererHeader`, which only patches Capacitor's main WebView during `cap sync`.
+
 ## Fix YouTube Referer Blocking in the Main WebView
 
 If YouTube works inside the plugin but breaks when the same app loads YouTube pages, embeds, or APIs through Capacitor's main WebView, this plugin can ship the fix for you.

--- a/ios/Sources/YoutubePlayerPlugin/YoutubePlayerPlugin.swift
+++ b/ios/Sources/YoutubePlayerPlugin/YoutubePlayerPlugin.swift
@@ -20,6 +20,7 @@ public class YoutubePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
     private struct PlayerInstance {
         let webView: WKWebView
         let viewController: UIViewController
+        let schemeHandler: YoutubePlayerRefererURLSchemeHandler
     }
     
     public let pluginMethods: [CAPPluginMethod] = [
@@ -94,20 +95,89 @@ public class YoutubePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    private func youtubeRefererValue() -> String {
+        let configuredReferer = getConfig().getString("refererHeader", YoutubePlayerRefererURLSchemeHandler.defaultReferer)
+        if YoutubePlayerRefererURLSchemeHandler.isValidReferer(configuredReferer) {
+            return configuredReferer!
+        }
+        return YoutubePlayerRefererURLSchemeHandler.defaultReferer
+    }
+
+    private func buildPlayerHTML(videoId: String, playerVarsJSON: String) -> String {
+        let escapedVideoId = escapeJavaScript(videoId)
+        let scheme = YoutubePlayerRefererURLSchemeHandler.scheme
+        return """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <base href="\(scheme)://www.youtube.com/">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+            <meta name="referrer" content="strict-origin-when-cross-origin">
+            <style>
+                body, html {
+                    margin: 0;
+                    padding: 0;
+                    width: 100%;
+                    height: 100%;
+                    background-color: #000;
+                }
+                #player {
+                    width: 100%;
+                    height: 100%;
+                }
+            </style>
+        </head>
+        <body>
+            <div id="player"></div>
+            <script src="/iframe_api"></script>
+            <script>
+                var player;
+                window.playerReady = false;
+
+                function onYouTubeIframeAPIReady() {
+                    player = new YT.Player('player', {
+                        videoId: '\(escapedVideoId)',
+                        playerVars: \(playerVarsJSON),
+                        events: {
+                            'onReady': onPlayerReady
+                        }
+                    });
+                }
+
+                function onPlayerReady(event) {
+                    console.log('Player ready');
+                    window.playerReady = true;
+                }
+
+                function executePlayerCommand(command, ...args) {
+                    try {
+                        if (!window.playerReady || !player) {
+                            return { success: false, error: 'Player not ready' };
+                        }
+                        const result = player[command](...args);
+                        return { success: true, value: result };
+                    } catch (error) {
+                        return { success: false, error: error.message };
+                    }
+                }
+            </script>
+        </body>
+        </html>
+        """
+    }
+
     private func createPlayer(call: CAPPluginCall, playerId: String, videoId: String) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 
-            // Build player vars
             var playerVars: [String: Any] = [
-                "playsinline": 0,  // Force fullscreen
+                "playsinline": 0,
                 "controls": 1,
                 "showinfo": 0,
                 "rel": 0,
                 "modestbranding": 1
             ]
 
-            // Merge user-provided playerVars
             if let userPlayerVars = call.getObject("playerVars") {
                 for (key, value) in userPlayerVars {
                     playerVars[key] = value
@@ -117,92 +187,35 @@ public class YoutubePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             let autoplay = call.getBool("autoplay") ?? false
             playerVars["autoplay"] = autoplay ? 1 : 0
 
-            // Convert playerVars to JSON string
             let playerVarsJSON = (try? JSONSerialization.data(withJSONObject: playerVars))
                 .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
 
-            // Create WKWebView configuration
+            let referer = self.youtubeRefererValue()
+            let playerHTML = self.buildPlayerHTML(videoId: videoId, playerVarsJSON: playerVarsJSON)
+            let schemeHandler = YoutubePlayerRefererURLSchemeHandler(referer: referer, playerHTML: playerHTML)
+
             let configuration = WKWebViewConfiguration()
             configuration.allowsInlineMediaPlayback = false
             configuration.mediaTypesRequiringUserActionForPlayback = []
+            configuration.setURLSchemeHandler(schemeHandler, forURLScheme: YoutubePlayerRefererURLSchemeHandler.scheme)
 
-            // Create WKWebView
             let webView = WKWebView(frame: .zero, configuration: configuration)
             webView.scrollView.isScrollEnabled = false
             webView.backgroundColor = .black
 
-            // Create fullscreen view controller
             let playerViewController = UIViewController()
             playerViewController.view = webView
             playerViewController.modalPresentationStyle = .fullScreen
 
-            // Load HTML with video
-            let escapedVideoId = escapeJavaScript(videoId)
-            let htmlString = """
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-                <style>
-                    body, html {
-                        margin: 0;
-                        padding: 0;
-                        width: 100%;
-                        height: 100%;
-                        background-color: #000;
-                    }
-                    #player {
-                        width: 100%;
-                        height: 100%;
-                    }
-                </style>
-            </head>
-            <body>
-                <div id="player"></div>
-                <script src="https://www.youtube.com/iframe_api"></script>
-                <script>
-                    var player;
-                    window.playerReady = false;
-                    
-                    function onYouTubeIframeAPIReady() {
-                        player = new YT.Player('player', {
-                            videoId: '\(escapedVideoId)',
-                            playerVars: \(playerVarsJSON),
-                            events: {
-                                'onReady': onPlayerReady
-                            }
-                        });
-                    }
-                    
-                    function onPlayerReady(event) {
-                        console.log('Player ready');
-                        window.playerReady = true;
-                    }
-                    
-                    // Helper function to execute player commands
-                    function executePlayerCommand(command, ...args) {
-                        try {
-                            if (!window.playerReady || !player) {
-                                return { success: false, error: 'Player not ready' };
-                            }
-                            const result = player[command](...args);
-                            return { success: true, value: result };
-                        } catch (error) {
-                            return { success: false, error: error.message };
-                        }
-                    }
-                </script>
-            </body>
-            </html>
-            """
+            webView.load(URLRequest(url: YoutubePlayerRefererURLSchemeHandler.playerPageURL()))
 
-            webView.loadHTMLString(htmlString, baseURL: URL(string: "https://www.youtube.com"))
-
-            // Store player instance
-            let playerInstance = PlayerInstance(webView: webView, viewController: playerViewController)
+            let playerInstance = PlayerInstance(
+                webView: webView,
+                viewController: playerViewController,
+                schemeHandler: schemeHandler
+            )
             self.players[playerId] = playerInstance
 
-            // Present fullscreen
             self.bridge?.viewController?.present(playerViewController, animated: true) {
                 call.resolve([
                     "playerReady": true,
@@ -211,9 +224,7 @@ public class YoutubePlayerPlugin: CAPPlugin, CAPBridgedPlugin {
             }
         }
     }
-    
-    // MARK: - Helper Methods
-    
+
     private func escapeJavaScript(_ string: String) -> String {
         return string
             .replacingOccurrences(of: "\\", with: "\\\\")

--- a/ios/Sources/YoutubePlayerPlugin/YoutubePlayerRefererURLSchemeHandler.swift
+++ b/ios/Sources/YoutubePlayerPlugin/YoutubePlayerRefererURLSchemeHandler.swift
@@ -1,0 +1,163 @@
+import Foundation
+import WebKit
+
+final class YoutubePlayerRefererURLSchemeHandler: NSObject, WKURLSchemeHandler {
+    static let scheme = "capgo-youtube"
+    static let defaultReferer = "https://www.youtube.com"
+
+    private let referer: String
+    private let playerHTML: String
+    private var activeTasks: [ObjectIdentifier: URLSessionDataTask] = [:]
+    private let lock = NSLock()
+
+    init(referer: String, playerHTML: String) {
+        self.referer = referer
+        self.playerHTML = playerHTML
+        super.init()
+    }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let requestURL = urlSchemeTask.request.url else {
+            urlSchemeTask.didFailWithError(Self.missingURLError())
+            return
+        }
+
+        if Self.isPlayerPage(requestURL) {
+            servePlayerHTML(to: urlSchemeTask, requestURL: requestURL)
+            return
+        }
+
+        guard let httpsURL = Self.httpsURL(from: requestURL) else {
+            urlSchemeTask.didFailWithError(Self.invalidProxyURLError(requestURL))
+            return
+        }
+
+        var request = URLRequest(url: httpsURL)
+        if request.value(forHTTPHeaderField: "Referer") == nil {
+            request.setValue(referer, forHTTPHeaderField: "Referer")
+        }
+
+        let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            DispatchQueue.main.async {
+                guard let self else { return }
+
+                self.lock.lock()
+                self.activeTasks.removeValue(forKey: ObjectIdentifier(urlSchemeTask))
+                self.lock.unlock()
+
+                if let error = error {
+                    urlSchemeTask.didFailWithError(error)
+                    return
+                }
+
+                guard let response = response else {
+                    urlSchemeTask.didFailWithError(Self.emptyResponseError())
+                    return
+                }
+
+                urlSchemeTask.didReceive(response)
+
+                if let data = data {
+                    urlSchemeTask.didReceive(data)
+                }
+
+                urlSchemeTask.didFinish()
+            }
+        }
+
+        lock.lock()
+        activeTasks[ObjectIdentifier(urlSchemeTask)] = task
+        lock.unlock()
+        task.resume()
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+        lock.lock()
+        let task = activeTasks.removeValue(forKey: ObjectIdentifier(urlSchemeTask))
+        lock.unlock()
+        task?.cancel()
+    }
+
+    static func playerPageURL() -> URL {
+        URL(string: "\(scheme)://www.youtube.com/player")!
+    }
+
+    static func httpsURL(from url: URL) -> URL? {
+        guard url.scheme == scheme else {
+            return nil
+        }
+
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        components.scheme = "https"
+        if components.port == 443 {
+            components.port = nil
+        }
+        if components.path.isEmpty {
+            components.path = "/"
+        }
+        return components.url
+    }
+
+    static func isValidReferer(_ referer: String?) -> Bool {
+        guard
+            let referer,
+            let url = URL(string: referer),
+            let host = url.host,
+            !host.isEmpty,
+            let scheme = url.scheme?.lowercased(),
+            scheme == "http" || scheme == "https"
+        else {
+            return false
+        }
+
+        return true
+    }
+
+    private static func isPlayerPage(_ url: URL) -> Bool {
+        guard url.scheme == scheme, url.host == "www.youtube.com" else {
+            return false
+        }
+
+        let path = url.path
+        return path == "/player" || path == "/player/"
+    }
+
+    private func servePlayerHTML(to urlSchemeTask: WKURLSchemeTask, requestURL: URL) {
+        let data = Data(playerHTML.utf8)
+        let headers = ["Content-Type": "text/html; charset=utf-8"]
+        let response = HTTPURLResponse(
+            url: requestURL,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers
+        )
+
+        guard let response else {
+            urlSchemeTask.didFailWithError(Self.emptyResponseError())
+            return
+        }
+
+        urlSchemeTask.didReceive(response)
+        urlSchemeTask.didReceive(data)
+        urlSchemeTask.didFinish()
+    }
+
+    private static func missingURLError() -> NSError {
+        NSError(domain: "YoutubePlayer", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing request URL"])
+    }
+
+    private static func invalidProxyURLError(_ url: URL) -> NSError {
+        NSError(
+            domain: "YoutubePlayer",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "Unable to proxy URL: \(url.absoluteString)"]
+        )
+    }
+
+    private static func emptyResponseError() -> NSError {
+        NSError(domain: "YoutubePlayer", code: 3, userInfo: [NSLocalizedDescriptionKey: "Empty response from proxied request"])
+    }
+}

--- a/ios/Tests/YoutubePlayerPluginTests/YoutubePlayerPluginTests.swift
+++ b/ios/Tests/YoutubePlayerPluginTests/YoutubePlayerPluginTests.swift
@@ -18,6 +18,34 @@ class YoutubePlayerTests: XCTestCase {
         super.tearDown()
     }
 
+
+    // MARK: - Referer Proxy Tests
+
+    func testHttpsURLConversion() {
+        let proxyURL = URL(string: "capgo-youtube://www.youtube.com/iframe_api")!
+        let httpsURL = YoutubePlayerRefererURLSchemeHandler.httpsURL(from: proxyURL)
+        XCTAssertEqual(httpsURL?.absoluteString, "https://www.youtube.com/iframe_api")
+    }
+
+    func testHttpsURLConversionWithQuery() {
+        let proxyURL = URL(string: "capgo-youtube://www.youtube.com/embed/test?autoplay=1")!
+        let httpsURL = YoutubePlayerRefererURLSchemeHandler.httpsURL(from: proxyURL)
+        XCTAssertEqual(httpsURL?.absoluteString, "https://www.youtube.com/embed/test?autoplay=1")
+    }
+
+    func testInvalidRefererFallsBackToValidation() {
+        XCTAssertFalse(YoutubePlayerRefererURLSchemeHandler.isValidReferer("capacitor://localhost"))
+        XCTAssertFalse(YoutubePlayerRefererURLSchemeHandler.isValidReferer(nil))
+        XCTAssertTrue(YoutubePlayerRefererURLSchemeHandler.isValidReferer("https://www.youtube.com"))
+    }
+
+    func testPlayerPageURLUsesProxyScheme() {
+        XCTAssertEqual(
+            YoutubePlayerRefererURLSchemeHandler.playerPageURL().absoluteString,
+            "capgo-youtube://www.youtube.com/player"
+        )
+    }
+
     // MARK: - Echo Tests
 
     func testEcho() {


### PR DESCRIPTION
## Summary
- Fix YouTube error 152-4 on iOS by proxying the plugin's native fullscreen WKWebView requests through a custom `capgo-youtube` URL scheme handler
- Inject a valid HTTP `Referer` header (from `plugins.YoutubePlayer.refererHeader`, default `https://www.youtube.com`) on all proxied YouTube requests, including iframe API and embed loads
- Add unit tests for URL conversion and referer validation; document the plugin WKWebView behavior in README

Fixes #49

## Root cause
`patchRefererHeader` only patches Capacitor's main WebView during `cap sync`. The plugin creates its own WKWebView modal, which still loaded YouTube resources without a valid `Referer` header.

## Approach
1. Serve the player HTML from `capgo-youtube://www.youtube.com/player`
2. Load iframe API and embed resources through the same scheme via `<base href>`
3. Proxy each request to `https://www.youtube.com/...` with the configured `Referer` header

## Test plan
- [x] `bun run verify:ios`
- [x] iOS unit tests pass on simulator (including new referer proxy tests)
- [ ] Manual test: `YoutubePlayer.initialize()` on iOS device/simulator plays public videos without error 152-4


Made with [Cursor](https://cursor.com)